### PR TITLE
 Fix payload conversion to send in request

### DIFF
--- a/dist/aws-request.js
+++ b/dist/aws-request.js
@@ -233,7 +233,7 @@ function request(params) {
     path = '/' + path;
   }
 
-  var payloadString = '';
+  var payloadString = payload;
   if (typeof payload !== 'string') {
     payloadString = JSON.stringify(payload);
   }


### PR DESCRIPTION
When payload is not an object (JSON) it's not sent in request body.