### PR TITLE
Fix payload conversion to send in request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -75,7 +75,7 @@ function request(params) {
     path = '/' + path;
   }
 
-  var payloadString = '';
+  var payloadString = payload;
   if (typeof payload !== 'string') {
     payloadString = JSON.stringify(payload);
   }


### PR DESCRIPTION
When payload is not an object, it's not sent.